### PR TITLE
Add initial Profanus solution with basic layers and Blazor UI

### DIFF
--- a/Profanus.sln
+++ b/Profanus.sln
@@ -1,0 +1,39 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31912.275
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Profanus.Domain", "src/Profanus.Domain/Profanus.Domain.csproj", "{0E6D816F-2F5F-450E-BF8C-65D63608CB0E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Profanus.Application", "src/Profanus.Application/Profanus.Application.csproj", "{CC48022E-D696-45DA-9F78-E7748B0806B2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Profanus.Infrastructure", "src/Profanus.Infrastructure/Profanus.Infrastructure.csproj", "{70FADBD2-7D51-4212-9545-F55F7C2D0202}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Profanus.Presentation", "src/Profanus.Presentation/Profanus.Presentation.csproj", "{03B84BD2-36B2-425F-AB08-458DDA63A91B}"
+EndProject
+Global
+GlobalSection(SolutionConfigurationPlatforms) = preSolution
+Debug|Any CPU = Debug|Any CPU
+Release|Any CPU = Release|Any CPU
+EndGlobalSection
+GlobalSection(ProjectConfigurationPlatforms) = postSolution
+{0E6D816F-2F5F-450E-BF8C-65D63608CB0E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{0E6D816F-2F5F-450E-BF8C-65D63608CB0E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{0E6D816F-2F5F-450E-BF8C-65D63608CB0E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{0E6D816F-2F5F-450E-BF8C-65D63608CB0E}.Release|Any CPU.Build.0 = Release|Any CPU
+{CC48022E-D696-45DA-9F78-E7748B0806B2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{CC48022E-D696-45DA-9F78-E7748B0806B2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{CC48022E-D696-45DA-9F78-E7748B0806B2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{CC48022E-D696-45DA-9F78-E7748B0806B2}.Release|Any CPU.Build.0 = Release|Any CPU
+{70FADBD2-7D51-4212-9545-F55F7C2D0202}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{70FADBD2-7D51-4212-9545-F55F7C2D0202}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{70FADBD2-7D51-4212-9545-F55F7C2D0202}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{70FADBD2-7D51-4212-9545-F55F7C2D0202}.Release|Any CPU.Build.0 = Release|Any CPU
+{03B84BD2-36B2-425F-AB08-458DDA63A91B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{03B84BD2-36B2-425F-AB08-458DDA63A91B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{03B84BD2-36B2-425F-AB08-458DDA63A91B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{03B84BD2-36B2-425F-AB08-458DDA63A91B}.Release|Any CPU.Build.0 = Release|Any CPU
+EndGlobalSection
+GlobalSection(SolutionProperties) = preSolution
+HideSolutionNode = FALSE
+EndGlobalSection
+EndGlobal

--- a/src/Profanus.Application/Interfaces/ISensorRepository.cs
+++ b/src/Profanus.Application/Interfaces/ISensorRepository.cs
@@ -1,0 +1,8 @@
+using Profanus.Domain.Entities;
+
+namespace Profanus.Application.Interfaces;
+
+public interface ISensorRepository
+{
+    Task<IEnumerable<Sensor>> GetSensorsAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Profanus.Application/Profanus.Application.csproj
+++ b/src/Profanus.Application/Profanus.Application.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>preview</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Profanus.Domain\Profanus.Domain.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Profanus.Application/Services/SensorService.cs
+++ b/src/Profanus.Application/Services/SensorService.cs
@@ -1,0 +1,17 @@
+using Profanus.Application.Interfaces;
+using Profanus.Domain.Entities;
+
+namespace Profanus.Application.Services;
+
+public class SensorService
+{
+    private readonly ISensorRepository _repository;
+
+    public SensorService(ISensorRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public Task<IEnumerable<Sensor>> GetSensorsAsync(CancellationToken cancellationToken = default)
+        => _repository.GetSensorsAsync(cancellationToken);
+}

--- a/src/Profanus.Domain/Entities/Dispositivo.cs
+++ b/src/Profanus.Domain/Entities/Dispositivo.cs
@@ -1,0 +1,10 @@
+namespace Profanus.Domain.Entities;
+
+public class Dispositivo
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string IpAddress { get; set; } = string.Empty;
+    public bool IsActive { get; set; }
+    public ICollection<Sensor> Sensors { get; set; } = new List<Sensor>();
+}

--- a/src/Profanus.Domain/Entities/Sensor.cs
+++ b/src/Profanus.Domain/Entities/Sensor.cs
@@ -1,0 +1,19 @@
+namespace Profanus.Domain.Entities;
+
+public enum SensorStatus
+{
+    Unknown = 0,
+    Online = 1,
+    Offline = 2
+}
+
+public class Sensor
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public SensorStatus Status { get; set; }
+    public DateTime LastReading { get; set; }
+    public Guid? DispositivoId { get; set; }
+    public Dispositivo? Dispositivo { get; set; }
+}

--- a/src/Profanus.Domain/Profanus.Domain.csproj
+++ b/src/Profanus.Domain/Profanus.Domain.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>preview</LangVersion>
+  </PropertyGroup>
+</Project>

--- a/src/Profanus.Infrastructure/Migrations/20240822000000_InitialCreate.cs
+++ b/src/Profanus.Infrastructure/Migrations/20240822000000_InitialCreate.cs
@@ -1,0 +1,62 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Profanus.Infrastructure.Migrations
+{
+    public partial class InitialCreate : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Dispositivos",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    IpAddress = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                    IsActive = table.Column<bool>(type: "bit", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Dispositivos", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Sensors",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    Description = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    Status = table.Column<int>(type: "int", nullable: false),
+                    LastReading = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    DispositivoId = table.Column<Guid>(type: "uniqueidentifier", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Sensors", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Sensors_Dispositivos_DispositivoId",
+                        column: x => x.DispositivoId,
+                        principalTable: "Dispositivos",
+                        principalColumn: "Id");
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Sensors_DispositivoId",
+                table: "Sensors",
+                column: "DispositivoId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Sensors");
+
+            migrationBuilder.DropTable(
+                name: "Dispositivos");
+        }
+    }
+}

--- a/src/Profanus.Infrastructure/Migrations/ProfanusDbContextModelSnapshot.cs
+++ b/src/Profanus.Infrastructure/Migrations/ProfanusDbContextModelSnapshot.cs
@@ -1,0 +1,43 @@
+using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Profanus.Infrastructure;
+
+#nullable disable
+
+namespace Profanus.Infrastructure.Migrations
+{
+    [DbContext(typeof(ProfanusDbContext))]
+    partial class ProfanusDbContextModelSnapshot : ModelSnapshot
+    {
+        protected override void BuildModel(ModelBuilder modelBuilder)
+        {
+            modelBuilder.HasAnnotation("ProductVersion", "9.0.0-preview");
+
+            modelBuilder.Entity("Profanus.Domain.Entities.Dispositivo", b =>
+            {
+                b.Property<Guid>("Id").ValueGeneratedOnAdd().HasColumnType("uniqueidentifier");
+                b.Property<string>("Name").IsRequired().HasMaxLength(100).HasColumnType("nvarchar(100)");
+                b.Property<string>("IpAddress").IsRequired().HasMaxLength(50).HasColumnType("nvarchar(50)");
+                b.Property<bool>("IsActive").HasColumnType("bit");
+                b.HasKey("Id");
+                b.ToTable("Dispositivos");
+            });
+
+            modelBuilder.Entity("Profanus.Domain.Entities.Sensor", b =>
+            {
+                b.Property<Guid>("Id").ValueGeneratedOnAdd().HasColumnType("uniqueidentifier");
+                b.Property<string>("Name").IsRequired().HasMaxLength(100).HasColumnType("nvarchar(100)");
+                b.Property<string>("Description").HasColumnType("nvarchar(max)");
+                b.Property<int>("Status").HasColumnType("int");
+                b.Property<DateTime>("LastReading").HasColumnType("datetime2");
+                b.Property<Guid?>("DispositivoId").HasColumnType("uniqueidentifier");
+                b.HasKey("Id");
+                b.HasIndex("DispositivoId");
+                b.ToTable("Sensors");
+                b.HasOne("Profanus.Domain.Entities.Dispositivo", null).WithMany("Sensors").HasForeignKey("DispositivoId");
+            });
+        }
+    }
+}

--- a/src/Profanus.Infrastructure/Profanus.Infrastructure.csproj
+++ b/src/Profanus.Infrastructure/Profanus.Infrastructure.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>preview</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0-preview.2.24128.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0-preview.2.24128.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.0-preview.2.24128.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Profanus.Domain\Profanus.Domain.csproj" />
+    <ProjectReference Include="..\Profanus.Application\Profanus.Application.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Profanus.Infrastructure/ProfanusDbContext.cs
+++ b/src/Profanus.Infrastructure/ProfanusDbContext.cs
@@ -1,0 +1,33 @@
+using Microsoft.EntityFrameworkCore;
+using Profanus.Domain.Entities;
+
+namespace Profanus.Infrastructure;
+
+public class ProfanusDbContext : DbContext
+{
+    public ProfanusDbContext(DbContextOptions<ProfanusDbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<Sensor> Sensors => Set<Sensor>();
+    public DbSet<Dispositivo> Dispositivos => Set<Dispositivo>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Sensor>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Name).IsRequired().HasMaxLength(100);
+        });
+
+        modelBuilder.Entity<Dispositivo>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Name).IsRequired().HasMaxLength(100);
+            entity.Property(e => e.IpAddress).HasMaxLength(50);
+            entity.HasMany(d => d.Sensors)
+                  .WithOne(s => s.Dispositivo)
+                  .HasForeignKey(s => s.DispositivoId);
+        });
+    }
+}

--- a/src/Profanus.Infrastructure/Repositories/SensorRepository.cs
+++ b/src/Profanus.Infrastructure/Repositories/SensorRepository.cs
@@ -1,0 +1,20 @@
+using Microsoft.EntityFrameworkCore;
+using Profanus.Application.Interfaces;
+using Profanus.Domain.Entities;
+
+namespace Profanus.Infrastructure.Repositories;
+
+public class SensorRepository : ISensorRepository
+{
+    private readonly ProfanusDbContext _context;
+
+    public SensorRepository(ProfanusDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<IEnumerable<Sensor>> GetSensorsAsync(CancellationToken cancellationToken = default)
+    {
+        return await _context.Sensors.AsNoTracking().ToListAsync(cancellationToken);
+    }
+}

--- a/src/Profanus.Presentation/App.razor
+++ b/src/Profanus.Presentation/App.razor
@@ -1,0 +1,10 @@
+<Router AppAssembly="@typeof(App).Assembly">
+    <Found Context="routeData">
+        <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
+    </Found>
+    <NotFound>
+        <LayoutView Layout="@typeof(MainLayout)">
+            <p>Sorry, there's nothing at this address.</p>
+        </LayoutView>
+    </NotFound>
+</Router>

--- a/src/Profanus.Presentation/Pages/Index.razor
+++ b/src/Profanus.Presentation/Pages/Index.razor
@@ -1,0 +1,4 @@
+@page "/"
+
+<h1>Welcome to Profanus</h1>
+<p>Use the navigation menu to explore.</p>

--- a/src/Profanus.Presentation/Pages/Sensors.razor
+++ b/src/Profanus.Presentation/Pages/Sensors.razor
@@ -1,0 +1,31 @@
+@page "/sensors"
+@inject Profanus.Application.Services.SensorService SensorService
+
+<h3>Sensores</h3>
+
+@if (sensors == null)
+{
+    <p><em>Loading...</em></p>
+}
+else if (!sensors.Any())
+{
+    <p>Nenhum sensor cadastrado.</p>
+}
+else
+{
+    <ul>
+    @foreach (var s in sensors)
+    {
+        <li>@s.Name (@s.Status)</li>
+    }
+    </ul>
+}
+
+@code {
+    private IEnumerable<Profanus.Domain.Entities.Sensor>? sensors;
+
+    protected override async Task OnInitializedAsync()
+    {
+        sensors = await SensorService.GetSensorsAsync();
+    }
+}

--- a/src/Profanus.Presentation/Pages/_Host.cshtml
+++ b/src/Profanus.Presentation/Pages/_Host.cshtml
@@ -1,0 +1,17 @@
+@page "/"
+@namespace Profanus.Presentation.Pages
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <title>Profanus</title>
+    <base href="~/" />
+</head>
+<body>
+    <app>
+        <component type="typeof(App)" render-mode="ServerPrerendered" />
+    </app>
+    <script src="_framework/blazor.server.js"></script>
+</body>
+</html>

--- a/src/Profanus.Presentation/Profanus.Presentation.csproj
+++ b/src/Profanus.Presentation/Profanus.Presentation.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>preview</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Profanus.Domain\Profanus.Domain.csproj" />
+    <ProjectReference Include="..\Profanus.Application\Profanus.Application.csproj" />
+    <ProjectReference Include="..\Profanus.Infrastructure\Profanus.Infrastructure.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Profanus.Presentation/Program.cs
+++ b/src/Profanus.Presentation/Program.cs
@@ -1,0 +1,34 @@
+using Microsoft.EntityFrameworkCore;
+using Profanus.Infrastructure;
+using Profanus.Application.Interfaces;
+using Profanus.Infrastructure.Repositories;
+using Profanus.Application.Services;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddRazorPages();
+builder.Services.AddServerSideBlazor();
+
+var connectionString = builder.Configuration.GetConnectionString("DefaultConnection")
+    ?? "Server=(localdb)\\mssqllocaldb;Database=ProfanusDb;Trusted_Connection=True;MultipleActiveResultSets=true";
+
+builder.Services.AddDbContext<ProfanusDbContext>(options =>
+    options.UseSqlServer(connectionString));
+
+builder.Services.AddScoped<ISensorRepository, SensorRepository>();
+builder.Services.AddScoped<SensorService>();
+
+var app = builder.Build();
+
+if (!app.Environment.IsDevelopment())
+{
+    app.UseExceptionHandler("/Error");
+}
+
+app.UseStaticFiles();
+app.UseRouting();
+
+app.MapBlazorHub();
+app.MapFallbackToPage("/_Host");
+
+app.Run();

--- a/src/Profanus.Presentation/Shared/MainLayout.razor
+++ b/src/Profanus.Presentation/Shared/MainLayout.razor
@@ -1,0 +1,12 @@
+@inherits LayoutComponentBase
+
+<div class="page">
+    <div class="sidebar">
+        <NavMenu />
+    </div>
+    <main>
+        <article class="content px-4">
+            @Body
+        </article>
+    </main>
+</div>

--- a/src/Profanus.Presentation/Shared/NavMenu.razor
+++ b/src/Profanus.Presentation/Shared/NavMenu.razor
@@ -1,0 +1,6 @@
+<nav>
+    <ul>
+        <li><NavLink href="" Match="NavLinkMatch.All">Home</NavLink></li>
+        <li><NavLink href="sensors">Sensors</NavLink></li>
+    </ul>
+</nav>

--- a/src/Profanus.Presentation/_Imports.razor
+++ b/src/Profanus.Presentation/_Imports.razor
@@ -1,0 +1,4 @@
+@using Microsoft.AspNetCore.Components
+@using Microsoft.AspNetCore.Components.Web
+@using Profanus.Presentation
+@using Profanus.Presentation.Shared

--- a/src/Profanus.Presentation/appsettings.json
+++ b/src/Profanus.Presentation/appsettings.json
@@ -1,0 +1,12 @@
+{
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=ProfanusDb;Trusted_Connection=True;MultipleActiveResultSets=true"
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
## Summary
- scaffold Profanus solution with Domain, Application, Infrastructure, and Presentation projects
- implement Sensor and Dispositivo entities and EF Core context/migrations
- add Blazor Server app with sensor list component

## Testing
- `dotnet run --project src/Profanus.Presentation/Profanus.Presentation.csproj` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68a7fc2026c483218dc4402f8d5cf7e2